### PR TITLE
feat: add unlock rate limit error and hint

### DIFF
--- a/shared/lib/transactions/approvals.test.ts
+++ b/shared/lib/transactions/approvals.test.ts
@@ -1,0 +1,59 @@
+import {
+  buildApproveTransactionData,
+  buildIncreaseAllowanceTransactionData,
+  buildPermit2ApproveTransactionData,
+} from '../../../test/data/confirmations/token-approve';
+import { updateApprovalAmount } from './approvals';
+
+const SPENDER_MOCK = '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb';
+const TOKEN_ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
+const AMOUNT_MOCK = 123;
+const EXPIRATION_MOCK = 456;
+
+describe('Approvals Utils', () => {
+  describe('updateApprovalAmount', () => {
+    it('updates legacy approval amount', () => {
+      expect(
+        updateApprovalAmount(
+          buildApproveTransactionData(SPENDER_MOCK, AMOUNT_MOCK),
+          1.23,
+          5,
+        ),
+      ).toStrictEqual(buildApproveTransactionData(SPENDER_MOCK, 123000));
+    });
+
+    it('updates increaseAllowance amount', () => {
+      expect(
+        updateApprovalAmount(
+          buildIncreaseAllowanceTransactionData(SPENDER_MOCK, AMOUNT_MOCK),
+          1.23,
+          5,
+        ),
+      ).toStrictEqual(
+        buildIncreaseAllowanceTransactionData(SPENDER_MOCK, 123000),
+      );
+    });
+
+    it('updates Permit2 approval amount', () => {
+      expect(
+        updateApprovalAmount(
+          buildPermit2ApproveTransactionData(
+            SPENDER_MOCK,
+            TOKEN_ADDRESS_MOCK,
+            AMOUNT_MOCK,
+            EXPIRATION_MOCK,
+          ),
+          1.23,
+          5,
+        ),
+      ).toStrictEqual(
+        buildPermit2ApproveTransactionData(
+          SPENDER_MOCK,
+          TOKEN_ADDRESS_MOCK,
+          123000,
+          EXPIRATION_MOCK,
+        ),
+      );
+    });
+  });
+});

--- a/shared/lib/transactions/approvals.ts
+++ b/shared/lib/transactions/approvals.ts
@@ -1,0 +1,45 @@
+import { Hex, add0x } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
+import { Interface } from '@ethersproject/abi';
+import { parseApprovalTransactionData } from '../../modules/transaction.utils';
+
+const SIGNATURE_LEGACY = 'function approve(address,uint256)';
+const SIGNATURE_PERMIT2 = 'function approve(address,address,uint160,uint48)';
+const SIGNATURE_INCREASE_ALLOWANCE =
+  'function increaseAllowance(address,uint256)';
+
+export function updateApprovalAmount(
+  originalData: Hex,
+  newAmount: string | number | BigNumber,
+  decimals: number,
+): Hex {
+  const { name, tokenAddress } =
+    parseApprovalTransactionData(originalData) ?? {};
+
+  if (!name) {
+    throw new Error('Invalid approval transaction data');
+  }
+
+  const multiplier = new BigNumber(10).pow(decimals);
+  const value = add0x(new BigNumber(newAmount).times(multiplier).toString(16));
+
+  let signature = tokenAddress ? SIGNATURE_PERMIT2 : SIGNATURE_LEGACY;
+
+  if (name === 'increaseAllowance') {
+    signature = SIGNATURE_INCREASE_ALLOWANCE;
+  }
+
+  const iface = new Interface([signature]);
+  const decoded = iface.decodeFunctionData(name, originalData);
+
+  if (signature === SIGNATURE_PERMIT2) {
+    return iface.encodeFunctionData(name, [
+      tokenAddress,
+      decoded[1],
+      value,
+      decoded[3],
+    ]) as Hex;
+  }
+
+  return iface.encodeFunctionData(name, [decoded[0], value]) as Hex;
+}

--- a/shared/modules/transaction.utils.ts
+++ b/shared/modules/transaction.utils.ts
@@ -30,6 +30,19 @@ const INFERRABLE_TRANSACTION_TYPES: TransactionType[] = [
   TransactionType.simpleSend,
 ];
 
+const ABI_PERMIT_2_APPROVE = {
+  inputs: [
+    { internalType: 'address', name: 'token', type: 'address' },
+    { internalType: 'address', name: 'spender', type: 'address' },
+    { internalType: 'uint160', name: 'amount', type: 'uint160' },
+    { internalType: 'uint48', name: 'expiration', type: 'uint48' },
+  ],
+  name: 'approve',
+  outputs: [],
+  stateMutability: 'nonpayable',
+  type: 'function',
+};
+
 type InferTransactionTypeResult = {
   // The type of transaction
   type: TransactionType;
@@ -41,6 +54,7 @@ const erc20Interface = new Interface(abiERC20);
 const erc721Interface = new Interface(abiERC721);
 const erc1155Interface = new Interface(abiERC1155);
 const USDCInterface = new Interface(abiFiatTokenV2);
+const permit2Interface = new Interface([ABI_PERMIT_2_APPROVE]);
 
 /**
  * Determines if the maxFeePerGas and maxPriorityFeePerGas fields are supplied
@@ -109,28 +123,20 @@ export function txParamsAreDappSuggested(
  * @returns TransactionDescription | undefined
  */
 export function parseStandardTokenTransactionData(data: string) {
-  try {
-    return erc20Interface.parseTransaction({ data });
-  } catch {
-    // ignore and next try to parse with erc721 ABI
-  }
+  const interfaces = [
+    erc20Interface,
+    erc721Interface,
+    erc1155Interface,
+    USDCInterface,
+    permit2Interface,
+  ];
 
-  try {
-    return erc721Interface.parseTransaction({ data });
-  } catch {
-    // ignore and next try to parse with erc1155 ABI
-  }
-
-  try {
-    return erc1155Interface.parseTransaction({ data });
-  } catch {
-    // ignore and return undefined
-  }
-
-  try {
-    return USDCInterface.parseTransaction({ data });
-  } catch {
-    // ignore and return undefined
+  for (const iface of interfaces) {
+    try {
+      return iface.parseTransaction({ data });
+    } catch {
+      // Intentionally empty
+    }
   }
 
   return undefined;
@@ -339,20 +345,26 @@ export function parseApprovalTransactionData(data: Hex):
       amountOrTokenId?: BigNumber;
       isApproveAll?: boolean;
       isRevokeAll?: boolean;
+      name: string;
+      tokenAddress?: Hex;
     }
   | undefined {
   const transactionDescription = parseStandardTokenTransactionData(data);
   const { args, name } = transactionDescription ?? {};
 
   if (
-    !['approve', 'increaseAllowance', 'setApprovalForAll'].includes(name ?? '')
+    !['approve', 'increaseAllowance', 'setApprovalForAll'].includes(
+      name ?? '',
+    ) ||
+    !name
   ) {
     return undefined;
   }
 
   const rawAmountOrTokenId =
     args?._value ?? // ERC-20 - approve
-    args?.increment; // Fiat Token V2 - increaseAllowance
+    args?.increment ?? // Fiat Token V2 - increaseAllowance
+    args?.amount; // Permit2 - approve
 
   const amountOrTokenId = rawAmountOrTokenId
     ? new BigNumber(rawAmountOrTokenId?.toString())
@@ -360,10 +372,13 @@ export function parseApprovalTransactionData(data: Hex):
 
   const isApproveAll = name === 'setApprovalForAll' && args?._approved === true;
   const isRevokeAll = name === 'setApprovalForAll' && args?._approved === false;
+  const tokenAddress = name === 'approve' ? args?.token : undefined;
 
   return {
     amountOrTokenId,
     isApproveAll,
     isRevokeAll,
+    name,
+    tokenAddress,
   };
 }

--- a/test/data/confirmations/token-approve.ts
+++ b/test/data/confirmations/token-approve.ts
@@ -16,6 +16,17 @@ export function buildApproveTransactionData(
   ]).encodeFunctionData('approve', [address, amountOrTokenId]) as Hex;
 }
 
+export function buildPermit2ApproveTransactionData(
+  token: string,
+  spender: string,
+  amount: number,
+  expiration: number,
+): Hex {
+  return new Interface([
+    'function approve(address token, address spender, uint160 amount, uint48 nonce)',
+  ]).encodeFunctionData('approve', [token, spender, amount, expiration]) as Hex;
+}
+
 export function buildIncreaseAllowanceTransactionData(
   address: string,
   amount: number,

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useRef, useState, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { Hex } from '@metamask/utils';
 import {
-  getCurrentNetwork,
   getIsTokenNetworkFilterEqualCurrentNetwork,
-  getSelectedInternalAccount,
   getTokenNetworkFilter,
 } from '../../../../../selectors';
 import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
@@ -50,7 +49,6 @@ import {
   showImportTokensModal,
 } from '../../../../../store/actions';
 import Tooltip from '../../../../ui/tooltip';
-import { useMultichainSelector } from '../../../../../hooks/useMultichainSelector';
 import { getMultichainNetwork } from '../../../../../selectors/multichain';
 
 type AssetListControlBarProps = {
@@ -68,7 +66,7 @@ const AssetListControlBar = ({
   const dispatch = useDispatch();
   const trackEvent = useContext(MetaMetricsContext);
   const popoverRef = useRef<HTMLDivElement>(null);
-  const currentNetwork = useSelector(getCurrentNetwork);
+  const currentMultichainNetwork = useSelector(getMultichainNetwork);
   const allNetworks = useSelector(getNetworkConfigurationsByChainId);
   const isTokenNetworkFilterEqualCurrentNetwork = useSelector(
     getIsTokenNetworkFilterEqualCurrentNetwork,
@@ -81,12 +79,11 @@ const AssetListControlBar = ({
   const [isNetworkFilterPopoverOpen, setIsNetworkFilterPopoverOpen] =
     useState(false);
 
-  const account = useSelector(getSelectedInternalAccount);
-  const { isEvmNetwork } = useMultichainSelector(getMultichainNetwork, account);
-
   const isTestNetwork = useMemo(() => {
-    return (TEST_CHAINS as string[]).includes(currentNetwork.chainId);
-  }, [currentNetwork.chainId, TEST_CHAINS]);
+    return (TEST_CHAINS as string[]).includes(
+      currentMultichainNetwork.network.chainId,
+    );
+  }, [currentMultichainNetwork.network.chainId]);
 
   const allOpts: Record<string, boolean> = {};
   Object.keys(allNetworks || {}).forEach((chainId) => {
@@ -95,10 +92,12 @@ const AssetListControlBar = ({
 
   useEffect(() => {
     if (isTestNetwork) {
-      const testnetFilter = { [currentNetwork.chainId]: true };
+      const testnetFilter = {
+        [currentMultichainNetwork.network.chainId]: true,
+      };
       dispatch(setTokenNetworkFilter(testnetFilter));
     }
-  }, [isTestNetwork, currentNetwork.chainId, dispatch]);
+  }, [isTestNetwork, currentMultichainNetwork.network.chainId, dispatch]);
 
   // TODO: This useEffect should be a migration
   // We need to set the default filter for all users to be all included networks, rather than defaulting to empty object
@@ -107,7 +106,11 @@ const AssetListControlBar = ({
     if (Object.keys(tokenNetworkFilter).length === 0) {
       dispatch(setTokenNetworkFilter(allOpts));
     } else {
-      dispatch(setTokenNetworkFilter({ [currentNetwork.chainId]: true }));
+      dispatch(
+        setTokenNetworkFilter({
+          [currentMultichainNetwork.network.chainId]: true,
+        }),
+      );
     }
   }, []);
 
@@ -115,7 +118,11 @@ const AssetListControlBar = ({
   // We only want to do this if the "Current Network" filter is selected
   useEffect(() => {
     if (Object.keys(tokenNetworkFilter).length === 1) {
-      dispatch(setTokenNetworkFilter({ [currentNetwork.chainId]: true }));
+      dispatch(
+        setTokenNetworkFilter({
+          [currentMultichainNetwork.network.chainId]: true,
+        }),
+      );
     } else {
       dispatch(setTokenNetworkFilter(allOpts));
     }
@@ -171,6 +178,18 @@ const AssetListControlBar = ({
     });
   };
 
+  const isDisabled = useMemo(() => {
+    const isPopularNetwork = FEATURED_NETWORK_CHAIN_IDS.includes(
+      currentMultichainNetwork.network.chainId as Hex,
+    );
+
+    return (
+      !currentMultichainNetwork.isEvmNetwork ||
+      isTestNetwork ||
+      !isPopularNetwork
+    );
+  }, [currentMultichainNetwork, isTestNetwork]);
+
   return (
     <Box
       className="asset-list-control-bar"
@@ -178,39 +197,29 @@ const AssetListControlBar = ({
       marginRight={2}
       ref={popoverRef}
     >
-      <Box
-        display={Display.Flex}
-        justifyContent={
-          isEvmNetwork ? JustifyContent.spaceBetween : JustifyContent.flexEnd
-        }
-      >
-        {/* TODO: Remove isEvmNetwork check when we are ready to show the network filter in all networks including non-EVM */}
-        {isEvmNetwork ? (
-          <ButtonBase
-            data-testid="sort-by-networks"
-            variant={TextVariant.bodyMdMedium}
-            className="asset-list-control-bar__button asset-list-control-bar__network_control"
-            onClick={toggleNetworkFilterPopover}
-            size={ButtonBaseSize.Sm}
-            disabled={
-              isTestNetwork ||
-              !FEATURED_NETWORK_CHAIN_IDS.includes(currentNetwork.chainId)
-            }
-            endIconName={IconName.ArrowDown}
-            backgroundColor={
-              isNetworkFilterPopoverOpen
-                ? BackgroundColor.backgroundPressed
-                : BackgroundColor.backgroundDefault
-            }
-            color={TextColor.textDefault}
-            marginRight={isFullScreen ? 2 : null}
-            ellipsis
-          >
-            {isTokenNetworkFilterEqualCurrentNetwork
-              ? currentNetwork?.nickname ?? t('currentNetwork')
-              : t('popularNetworks')}
-          </ButtonBase>
-        ) : null}
+      <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>
+        <ButtonBase
+          data-testid="sort-by-networks"
+          variant={TextVariant.bodyMdMedium}
+          className="asset-list-control-bar__button asset-list-control-bar__network_control"
+          onClick={toggleNetworkFilterPopover}
+          size={ButtonBaseSize.Sm}
+          disabled={isDisabled}
+          endIconName={IconName.ArrowDown}
+          backgroundColor={
+            isNetworkFilterPopoverOpen
+              ? BackgroundColor.backgroundPressed
+              : BackgroundColor.backgroundDefault
+          }
+          color={TextColor.textDefault}
+          marginRight={isFullScreen ? 2 : null}
+          ellipsis
+        >
+          {isTokenNetworkFilterEqualCurrentNetwork ||
+          !currentMultichainNetwork.isEvmNetwork
+            ? currentMultichainNetwork?.nickname ?? t('currentNetwork')
+            : t('popularNetworks')}
+        </ButtonBase>
 
         <Box
           className="asset-list-control-bar__buttons"

--- a/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
+++ b/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
@@ -122,7 +122,7 @@ export const useTokenDisplayInfo = ({
     title: token.title,
     tokenImage: token.image,
     primary: formattedPrimary,
-    secondary: token.secondary,
+    secondary: showFiat ? token.secondary : null,
     isStakeable: false,
     tokenChainImage: token.image as string,
   };

--- a/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
+++ b/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
@@ -7,7 +7,6 @@ import {
   JustifyContent,
 } from '../../../../../helpers/constants/design-system';
 import { Box } from '../../../../component-library';
-import Spinner from '../../../../ui/spinner';
 import { getNftImageAlt, getNftImage } from '../../../../../helpers/utils/nfts';
 import { NftItem } from '../../../../multichain/nft-item';
 import { NFT } from '../../../../multichain/asset-picker-amount/asset-picker-modal/types';
@@ -22,6 +21,7 @@ import useFetchNftDetailsFromTokenURI from '../../../../../hooks/useFetchNftDeta
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { isWebUrl } from '../../../../../../app/scripts/lib/util';
+import PulseLoader from '../../../../ui/pulse-loader';
 import NFTGridItemErrorBoundary from './nft-grid-item-error-boundary';
 
 const NFTGridItem = (props: {
@@ -114,10 +114,9 @@ export default function NftGrid({
           display={Display.Flex}
           marginTop={4}
         >
-          <Spinner
-            color="var(--color-warning-default)"
-            className="loading-overlay__spinner"
-          />
+          <Box marginTop={4} marginBottom={4}>
+            <PulseLoader />
+          </Box>
         </Box>
       ) : null}
     </Box>

--- a/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
+++ b/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
@@ -36,7 +36,6 @@ import {
   MetaMetricsEventName,
 } from '../../../../../../shared/constants/metametrics';
 import { getCurrentLocale } from '../../../../../ducks/locale/locale';
-import Spinner from '../../../../ui/spinner';
 import { endTrace, TraceName } from '../../../../../../shared/lib/trace';
 import { useNfts } from '../../../../../hooks/useNfts';
 import { NFT } from '../../../../multichain/asset-picker-amount/asset-picker-modal/types';
@@ -55,6 +54,7 @@ import ZENDESK_URLS from '../../../../../helpers/constants/zendesk-url';
 ///: END:ONLY_INCLUDE_IF
 import { sortAssets } from '../../util/sort';
 import AssetListControlBar from '../../asset-list/asset-list-control-bar';
+import PulseLoader from '../../../../ui/pulse-loader';
 
 export default function NftsTab() {
   const history = useHistory();
@@ -139,10 +139,9 @@ export default function NftsTab() {
         display={Display.Flex}
         marginTop={4}
       >
-        <Spinner
-          color="var(--color-warning-default)"
-          className="loading-overlay__spinner"
-        />
+        <Box marginTop={4} marginBottom={4}>
+          <PulseLoader />
+        </Box>
       </Box>
     );
   }

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
@@ -14,7 +14,10 @@ import {
   SensitiveText,
   SensitiveTextLength,
 } from '../../../../component-library';
-import { getCurrencyRates } from '../../../../../selectors';
+import {
+  getCurrencyRates,
+  getUseCurrencyRateCheck,
+} from '../../../../../selectors';
 import { getMultichainIsEvm } from '../../../../../selectors/multichain';
 import { TokenFiatDisplayInfo } from '../../types';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
@@ -38,6 +41,15 @@ export const TokenCellSecondaryDisplay = React.memo(
     const isOriginalTokenSymbol = token.symbol && currencyRates[token.symbol];
 
     const showScamWarning = token.isNative && !isOriginalTokenSymbol && isEvm;
+
+    const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
+
+    const getSecondaryDisplayText = () => {
+      if (!useCurrencyRateCheck) {
+        return '';
+      }
+      return token.secondary || t('noConversionRateAvailable');
+    };
 
     // show scam warning
     if (showScamWarning) {
@@ -69,7 +81,7 @@ export const TokenCellSecondaryDisplay = React.memo(
         isHidden={privacyMode}
         length={SensitiveTextLength.Medium}
       >
-        {token.secondary || t('noConversionRateAvailable')}
+        {getSecondaryDisplayText()}
       </SensitiveText>
     );
   },

--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -11,6 +11,7 @@ import {
   getTokenList,
   getPreferences,
   getCurrencyRates,
+  getUseCurrencyRateCheck,
 } from '../../../../selectors';
 import {
   getMultichainCurrentChainId,
@@ -150,6 +151,9 @@ describe('Token Cell', () => {
     }
     if (selector === getCurrencyRates) {
       return { POL: '' };
+    }
+    if (selector === getUseCurrencyRateCheck) {
+      return true;
     }
     return undefined;
   });

--- a/ui/components/app/whats-new-modal/solana/modal-footer.tsx
+++ b/ui/components/app/whats-new-modal/solana/modal-footer.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   MetaMetricsEventCategory,
@@ -14,6 +14,7 @@ import {
 import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { hasCreatedSolanaAccount } from '../../../../selectors';
+import { selectIsAccountSyncingReadyToBeDispatched } from '../../../../selectors/identity/backup-and-sync';
 import { getLastSelectedSolanaAccount } from '../../../../selectors/multichain';
 import { setSelectedAccount } from '../../../../store/actions';
 import {
@@ -33,14 +34,10 @@ const GOT_IT_ACTION = 'got-it';
 export const SolanaModalFooter = ({ onAction, onCancel }: ModalFooterProps) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
+  const isLoading = !useSelector(selectIsAccountSyncingReadyToBeDispatched);
   const hasSolanaAccount = useSelector(hasCreatedSolanaAccount);
   const selectedSolanaAccount = useSelector(getLastSelectedSolanaAccount);
   const trackEvent = useContext(MetaMetricsContext);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    setIsLoading(false);
-  }, []);
 
   const handleCreateSolanaAccount = async () => {
     trackEvent({
@@ -105,6 +102,8 @@ export const SolanaModalFooter = ({ onAction, onCancel }: ModalFooterProps) => {
           size={ButtonSize.Md}
           variant={ButtonVariant.Primary}
           data-testid={buttonTestId}
+          loading={isLoading}
+          disabled={isLoading}
           onClick={
             hasSolanaAccount
               ? handleViewSolanaAccount

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -57,6 +57,7 @@ import {
   isSolanaAccount,
 } from '../../../selectors';
 import {
+  getMultichainBalances,
   getMultichainIsTestnet,
   getMultichainNativeCurrency,
   getMultichainNativeCurrencyImage,
@@ -122,7 +123,10 @@ const AccountListItem = ({
   );
 
   const useBlockie = useSelector(getUseBlockie);
-  const { isEvmNetwork } = useMultichainSelector(getMultichainNetwork, account);
+  const { isEvmNetwork, chainId: multichainChainId } = useMultichainSelector(
+    getMultichainNetwork,
+    account,
+  );
   const setAccountListItemMenuRef = (ref) => {
     setAccountListItemMenuElement(ref);
   };
@@ -143,6 +147,10 @@ const AccountListItem = ({
     getMultichainAggregatedBalance(state, account),
   );
 
+  const multichainBalances = useSelector(getMultichainBalances);
+  const accountMultichainBalances = multichainBalances?.[account.id];
+  const accountMultichainNativeBalance =
+    accountMultichainBalances?.[`${multichainChainId}/slip44:501`]?.amount;
   // cross chain agg balance
   const shouldHideZeroBalanceTokens = useSelector(
     getShouldHideZeroBalanceTokens,
@@ -176,7 +184,10 @@ const AccountListItem = ({
         ? account.balance
         : totalFiatBalance;
   } else {
-    balanceToTranslate = multichainAggregatedBalance;
+    balanceToTranslate =
+      !shouldShowFiat || isTestnet
+        ? accountMultichainNativeBalance
+        : multichainAggregatedBalance;
   }
 
   // If this is the selected item in the Account menu,
@@ -207,7 +218,7 @@ const AccountListItem = ({
   const getIsAggregatedFiatOverviewBalanceProp = () => {
     const isAggregatedFiatOverviewBalance =
       (!isTestnet && process.env.PORTFOLIO_VIEW && shouldShowFiat) ||
-      !isEvmNetwork;
+      (!isEvmNetwork && shouldShowFiat);
 
     return isAggregatedFiatOverviewBalance;
   };

--- a/ui/components/ui/aggregated-balance/aggregated-balance.tsx
+++ b/ui/components/ui/aggregated-balance/aggregated-balance.tsx
@@ -27,10 +27,14 @@ import {
   getMultichainNativeTokenBalance,
 } from '../../../selectors/assets';
 import { getPreferences, getSelectedInternalAccount } from '../../../selectors';
-import { getMultichainNetwork } from '../../../selectors/multichain';
+import {
+  getMultichainNetwork,
+  getMultichainShouldShowFiat,
+} from '../../../selectors/multichain';
 import { formatWithThreshold } from '../../app/assets/util/formatWithThreshold';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import Spinner from '../spinner';
+import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 
 export const AggregatedBalance = ({
   classPrefix,
@@ -55,6 +59,11 @@ export const AggregatedBalance = ({
   const multichainNativeTokenBalance = useSelector((state) =>
     getMultichainNativeTokenBalance(state, selectedAccount),
   );
+  const shouldShowFiat = useMultichainSelector(
+    getMultichainShouldShowFiat,
+    selectedAccount,
+  );
+
   const multichainAssetsRates = useSelector(getAssetsRates);
   const isNonEvmRatesAvailable = Object.keys(multichainAssetsRates).length > 0;
 
@@ -99,7 +108,9 @@ export const AggregatedBalance = ({
           isHidden={privacyMode}
           data-testid="account-value-and-suffix"
         >
-          {showNativeTokenAsMainBalance || !isNonEvmRatesAvailable
+          {showNativeTokenAsMainBalance ||
+          !isNonEvmRatesAvailable ||
+          !shouldShowFiat
             ? formattedTokenDisplay
             : formattedFiatDisplay}
         </SensitiveText>
@@ -108,7 +119,9 @@ export const AggregatedBalance = ({
           variant={TextVariant.inherit}
           isHidden={privacyMode}
         >
-          {showNativeTokenAsMainBalance || !isNonEvmRatesAvailable
+          {showNativeTokenAsMainBalance ||
+          !isNonEvmRatesAvailable ||
+          !shouldShowFiat
             ? currentNetwork.network.ticker
             : currentCurrency.toUpperCase()}
         </SensitiveText>

--- a/ui/components/ui/aggregated-balance/index.test.tsx
+++ b/ui/components/ui/aggregated-balance/index.test.tsx
@@ -236,4 +236,34 @@ describe('AggregatedBalance Component', () => {
     );
     expect(screen.getByText('SOL')).toBeInTheDocument();
   });
+
+  it('renders token balance when setting prices is disabled', () => {
+    renderWithProvider(
+      <AggregatedBalance
+        classPrefix="test"
+        balanceIsCached={false}
+        handleSensitiveToggle={jest.fn()}
+      />,
+      getStore({
+        metamask: {
+          ...mockMetamaskStore,
+          useCurrencyRateCheck: false,
+          preferences: {
+            showNativeTokenAsMainBalance: false,
+          },
+          conversionRates: {
+            [MultichainNativeAssets.SOLANA]: {
+              rate: '1.000',
+              conversionDate: 0,
+            },
+          },
+        },
+      }),
+    );
+
+    expect(screen.getByTestId('account-value-and-suffix')).toHaveTextContent(
+      '1',
+    );
+    expect(screen.getByText('SOL')).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/__snapshots__/edit-spending-cap-modal.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/__snapshots__/edit-spending-cap-modal.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`EditSpendingCapModal renders component 1`] = `
             <p
               class="mm-box mm-text mm-text--body-sm mm-box--padding-top-1 mm-box--color-text-alternative"
             >
-              Account balance: 0.000000000001 TST
+              Account balance: 100 TST
             </p>
           </div>
           <div

--- a/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.test.tsx
@@ -1,9 +1,15 @@
 import React, { ReactNode } from 'react';
 import configureMockStore from 'redux-mock-store';
 import { Hex } from '@metamask/utils';
-import { act } from '@testing-library/react';
-import { getMockApproveConfirmState } from '../../../../../../../../test/data/confirmations/helper';
+import { act, fireEvent } from '@testing-library/react';
+import {
+  getMockApproveConfirmState,
+  getMockConfirmStateForTransaction,
+} from '../../../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../../../test/data/confirmations/contract-interaction';
+import { buildPermit2ApproveTransactionData } from '../../../../../../../../test/data/confirmations/token-approve';
+import { useAssetDetails } from '../../../../../hooks/useAssetDetails';
 import {
   countDecimalDigits,
   EditSpendingCapModal,
@@ -38,14 +44,27 @@ jest.mock('../hooks/use-approve-token-simulation', () => ({
 
 jest.mock('../../../../../hooks/useAssetDetails', () => ({
   useAssetDetails: jest.fn(() => ({
-    decimals: 18,
+    decimals: 4,
     userBalance: '1000000',
     tokenSymbol: 'TST',
   })),
 }));
 
-function render({ onSubmit }: { onSubmit?: (data: Hex) => void } = {}) {
-  const state = getMockApproveConfirmState();
+const ADDRESS_MOCK = '0x1234567890123456789012345678901234567890';
+const ADDRESS_MOCK_2 = '0x1234567890123456789012345678901234567891';
+
+function render({
+  transactionData,
+  onSubmit,
+}: { transactionData?: Hex; onSubmit?: (data: Hex) => void } = {}) {
+  const state = transactionData
+    ? getMockConfirmStateForTransaction(
+        genUnapprovedContractInteractionConfirmation({
+          txData: transactionData,
+        }),
+      )
+    : getMockApproveConfirmState();
+
   const mockStore = configureMockStore()(state);
 
   return renderWithConfirmContextProvider(
@@ -76,6 +95,46 @@ describe('EditSpendingCapModal', () => {
     });
 
     expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('supports Permit2 approval', async () => {
+    const onSubmit = jest.fn();
+
+    const { getByText, getByTestId } = render({
+      onSubmit,
+      transactionData: buildPermit2ApproveTransactionData(
+        ADDRESS_MOCK,
+        ADDRESS_MOCK_2,
+        78900,
+        456,
+      ),
+    });
+
+    await act(async () => {
+      fireEvent.change(getByTestId('custom-spending-cap-input'), {
+        target: { value: '1.23' },
+      });
+    });
+
+    await act(async () => {
+      getByText('Save').click();
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      buildPermit2ApproveTransactionData(
+        ADDRESS_MOCK,
+        ADDRESS_MOCK_2,
+        12300,
+        456,
+      ),
+    );
+
+    expect(jest.mocked(useAssetDetails)).toHaveBeenCalledWith(
+      ADDRESS_MOCK,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   describe('countDecimalDigits()', () => {

--- a/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.tsx
@@ -28,10 +28,12 @@ import {
   estimateGas,
   updateEditableParams,
 } from '../../../../../../../store/actions';
-import { getCustomTxParamsData } from '../../../../../confirm-approve/confirm-approve.util';
 import { useConfirmContext } from '../../../../../context/confirm';
 import { useAssetDetails } from '../../../../../hooks/useAssetDetails';
 import { useApproveTokenSimulation } from '../hooks/use-approve-token-simulation';
+import { ConfirmLoader } from '../../shared/confirm-loader/confirm-loader';
+import { parseApprovalTransactionData } from '../../../../../../../../shared/modules/transaction.utils';
+import { updateApprovalAmount } from '../../../../../../../../shared/lib/transactions/approvals';
 
 export function countDecimalDigits(numberString: string) {
   return numberString.split('.')[1]?.length || 0;
@@ -59,13 +61,16 @@ export const EditSpendingCapModal = ({
 
   const currentTo = transactionMeta.txParams.to;
   const currentFrom = transactionMeta.txParams.from;
-  const currentData = transactionMeta.txParams.data;
+  const currentData = transactionMeta.txParams.data as Hex;
 
   const transactionTo = to ?? currentTo;
   const transactionData = data ?? currentData;
 
+  const { tokenAddress } =
+    parseApprovalTransactionData(transactionData ?? '0x') ?? {};
+
   const { userBalance, tokenSymbol, decimals } = useAssetDetails(
-    transactionTo,
+    tokenAddress ?? transactionTo,
     currentFrom,
     transactionData,
     transactionMeta.chainId,
@@ -89,10 +94,8 @@ export const EditSpendingCapModal = ({
     [currentFrom, transactionData, transactionMeta, transactionTo],
   );
 
-  const { formattedSpendingCap, spendingCap } = useApproveTokenSimulation(
-    finalTransactionMeta,
-    decimals,
-  );
+  const { formattedSpendingCap, pending, spendingCap } =
+    useApproveTokenSimulation(finalTransactionMeta, decimals);
 
   const [customSpendingCapInputValue, setCustomSpendingCapInputValue] =
     useState(spendingCap);
@@ -117,15 +120,11 @@ export const EditSpendingCapModal = ({
   const handleSubmit = useCallback(async () => {
     setIsModalSaving(true);
 
-    const customTxParamsData = getCustomTxParamsData(
-      finalTransactionMeta?.txParams?.data,
-      {
-        customPermissionAmount: customSpendingCapInputValue || '0',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        decimals: decimals || '0',
-      },
-    ) as Hex;
+    const customTxParamsData = updateApprovalAmount(
+      transactionData,
+      (customSpendingCapInputValue || '0').replace('#', ''),
+      Number(decimals || 0),
+    );
 
     if (onSubmit) {
       onSubmit(customTxParamsData);
@@ -156,6 +155,7 @@ export const EditSpendingCapModal = ({
     onSubmit,
     setIsOpenEditSpendingCapModal,
     spendingCap,
+    transactionData,
     transactionMeta.id,
   ]);
 
@@ -193,53 +193,59 @@ export const EditSpendingCapModal = ({
           >
             {t('editSpendingCapDesc')}
           </Text>
-          <TextField
-            type={TextFieldType.Number}
-            value={customSpendingCapInputValue}
-            onChange={(event) =>
-              setCustomSpendingCapInputValue(event.target.value)
-            }
-            placeholder={`${formattedSpendingCap} ${tokenSymbol}`}
-            style={{ width: '100%' }}
-            inputProps={{ 'data-testid': 'custom-spending-cap-input' }}
-          />
-          {showDecimalError && (
-            <Text
-              variant={TextVariant.bodySm}
-              color={TextColor.errorDefault}
-              paddingTop={1}
-            >
-              {t('editSpendingCapError', [decimals])}
-            </Text>
+          {pending ? (
+            <ConfirmLoader />
+          ) : (
+            <>
+              <TextField
+                type={TextFieldType.Number}
+                value={customSpendingCapInputValue}
+                onChange={(event) =>
+                  setCustomSpendingCapInputValue(event.target.value)
+                }
+                placeholder={`${formattedSpendingCap} ${tokenSymbol}`}
+                style={{ width: '100%' }}
+                inputProps={{ 'data-testid': 'custom-spending-cap-input' }}
+              />
+              {showDecimalError && (
+                <Text
+                  variant={TextVariant.bodySm}
+                  color={TextColor.errorDefault}
+                  paddingTop={1}
+                >
+                  {t('editSpendingCapError', [decimals])}
+                </Text>
+              )}
+              {showSpecialCharacterError && (
+                <Text
+                  variant={TextVariant.bodySm}
+                  color={TextColor.errorDefault}
+                  paddingTop={1}
+                >
+                  {t('editSpendingCapSpecialCharError')}
+                </Text>
+              )}
+              <Text
+                variant={TextVariant.bodySm}
+                color={TextColor.textAlternative}
+                paddingTop={1}
+              >
+                {t('editSpendingCapAccountBalance', [
+                  accountBalance,
+                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
+                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                  tokenSymbol || '',
+                ])}
+              </Text>
+            </>
           )}
-          {showSpecialCharacterError && (
-            <Text
-              variant={TextVariant.bodySm}
-              color={TextColor.errorDefault}
-              paddingTop={1}
-            >
-              {t('editSpendingCapSpecialCharError')}
-            </Text>
-          )}
-          <Text
-            variant={TextVariant.bodySm}
-            color={TextColor.textAlternative}
-            paddingTop={1}
-          >
-            {t('editSpendingCapAccountBalance', [
-              accountBalance,
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              tokenSymbol || '',
-            ])}
-          </Text>
         </ModalBody>
         <ModalFooter
           onSubmit={handleSubmit}
           onCancel={handleCancel}
           submitButtonProps={{
             children: t('save'),
-            loading: isModalSaving,
+            loading: pending || isModalSaving,
             disabled:
               // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
               // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/ui/pages/confirmations/components/confirm/info/approve/hooks/use-approve-token-simulation.ts
+++ b/ui/pages/confirmations/components/confirm/info/approve/hooks/use-approve-token-simulation.ts
@@ -10,8 +10,12 @@ import { TOKEN_VALUE_UNLIMITED_THRESHOLD } from '../../shared/constants';
 import { parseApprovalTransactionData } from '../../../../../../../../shared/modules/transaction.utils';
 import { useIsNFT } from './use-is-nft';
 
-export function isSpendingCapUnlimited(decodedSpendingCap: number) {
-  return decodedSpendingCap >= TOKEN_VALUE_UNLIMITED_THRESHOLD;
+export function isSpendingCapUnlimited(
+  value: number | string | BigNumber,
+  decimals: number = 0,
+) {
+  const finalValue = calcTokenAmount(value, decimals);
+  return finalValue.gte(TOKEN_VALUE_UNLIMITED_THRESHOLD);
 }
 
 export const useApproveTokenSimulation = (
@@ -19,12 +23,13 @@ export const useApproveTokenSimulation = (
   decimals: string | undefined,
 ) => {
   const locale = useSelector(getIntlLocale);
-  const { isNFT, pending: isNFTPending } = useIsNFT(transactionMeta);
+  const { isNFT: isToNFT, pending: isNFTPending } = useIsNFT(transactionMeta);
   const transactionData = transactionMeta?.txParams?.data as Hex | undefined;
 
-  const { amountOrTokenId: parsedValue } =
+  const { amountOrTokenId: parsedValue, tokenAddress } =
     parseApprovalTransactionData(transactionData ?? '0x') ?? {};
 
+  const isNFT = isToNFT && !tokenAddress;
   const value = parsedValue ?? new BigNumber(0);
 
   const decodedSpendingCap = calcTokenAmount(
@@ -38,7 +43,7 @@ export const useApproveTokenSimulation = (
     return isNFT
       ? `${tokenPrefix}${decodedSpendingCap}`
       : formatAmount(locale, new BigNumber(decodedSpendingCap));
-  }, [decodedSpendingCap, isNFT, locale]);
+  }, [decodedSpendingCap, isNFT, locale, tokenPrefix]);
 
   const { spendingCap, isUnlimitedSpendingCap } = useMemo(() => {
     if (!isNFT && isSpendingCapUnlimited(parseInt(decodedSpendingCap, 10))) {
@@ -48,7 +53,7 @@ export const useApproveTokenSimulation = (
       spendingCap: `${tokenPrefix}${decodedSpendingCap}`,
       isUnlimitedSpendingCap: false,
     };
-  }, [decodedSpendingCap, formattedSpendingCap, isNFT]);
+  }, [decodedSpendingCap, isNFT, tokenPrefix]);
 
   return {
     isUnlimitedSpendingCap,

--- a/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.test.tsx
@@ -20,8 +20,10 @@ import {
 } from '../../../../../../../../test/data/confirmations/batch-transaction';
 import { updateAtomicBatchData } from '../../../../../../../store/controller-actions/transaction-controller';
 import { Confirmation } from '../../../../../types/confirm';
-import { getCustomTxParamsData } from '../../../../../confirm-approve/confirm-approve.util';
+import { updateApprovalAmount } from '../../../../../../../../shared/lib/transactions/approvals';
 import { BatchSimulationDetails } from './batch-simulation-details';
+
+jest.mock('../../../../../../../../shared/lib/transactions/approvals');
 
 jest.mock('../../../../simulation-details/useBalanceChanges', () => ({
   useBalanceChanges: jest.fn(),
@@ -37,10 +39,6 @@ jest.mock(
     updateAtomicBatchData: jest.fn(),
   }),
 );
-
-jest.mock('../../../../../confirm-approve/confirm-approve.util', () => ({
-  getCustomTxParamsData: jest.fn(),
-}));
 
 const ADDRESS_MOCK = '0x1234567891234567891234567891234567891234';
 const ADDRESS_SHORT_MOCK = '0x12345...91234';
@@ -119,7 +117,7 @@ function render(transaction?: Confirmation) {
 describe('BatchSimulationDetails', () => {
   const useBalanceChangesMock = jest.mocked(useBalanceChanges);
   const updateAtomicBatchDataMock = jest.mocked(updateAtomicBatchData);
-  const getCustomTxParamsDataMock = jest.mocked(getCustomTxParamsData);
+  const updateApprovalAmountMock = jest.mocked(updateApprovalAmount);
 
   const useBatchApproveBalanceChangesMock = jest.mocked(
     useBatchApproveBalanceChanges,
@@ -265,7 +263,7 @@ describe('BatchSimulationDetails', () => {
       value: [BALANCE_CHANGE_ERC20_MOCK],
     });
 
-    getCustomTxParamsDataMock.mockReturnValue(DATA_MOCK);
+    updateApprovalAmountMock.mockReturnValue(DATA_MOCK);
 
     const { getByTestId, getByText } = render();
 

--- a/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.test.ts
@@ -15,7 +15,10 @@ import { getTokenStandardAndDetails } from '../../../../../../store/actions';
 import { TokenStandard } from '../../../../../../../shared/constants/transaction';
 import { renderHookWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
 import { BalanceChange } from '../../../simulation-details/types';
-import { buildApproveTransactionData } from '../../../../../../../test/data/confirmations/token-approve';
+import {
+  buildApproveTransactionData,
+  buildPermit2ApproveTransactionData,
+} from '../../../../../../../test/data/confirmations/token-approve';
 import { TOKEN_VALUE_UNLIMITED_THRESHOLD } from '../shared/constants';
 import { buildSetApproveForAllTransactionData } from '../../../../../../../test/data/confirmations/set-approval-for-all';
 import { useBatchApproveBalanceChanges } from './useBatchApproveBalanceChanges';
@@ -30,6 +33,7 @@ jest.mock('../../../../../../store/actions', () => ({
 }));
 
 const TO_MOCK = '0x1234567891234567891234567891234567891234';
+const TOKEN_ADDRESS_MOCK = '0x1234567891234567891234567891234567891235';
 const AMOUNT_MOCK = 123;
 const AMOUNT_HEX_MOCK = '0x7b';
 const DATA_MOCK = buildApproveTransactionData(TO_MOCK, AMOUNT_MOCK);
@@ -139,6 +143,46 @@ describe('useBatchApproveBalanceChanges', () => {
         ],
       },
     });
+  });
+
+  it('generates ERC-20 token balance changes from Permit2 approval', async () => {
+    await runHook({
+      nestedTransactions: [
+        {
+          data: buildPermit2ApproveTransactionData(
+            TOKEN_ADDRESS_MOCK,
+            TO_MOCK,
+            AMOUNT_MOCK,
+            456,
+          ),
+          to: TO_MOCK,
+        },
+      ],
+    });
+
+    expect(useBalanceChangesMock).toHaveBeenLastCalledWith({
+      chainId: CHAIN_ID,
+      simulationData: {
+        tokenBalanceChanges: [
+          {
+            address: TOKEN_ADDRESS_MOCK,
+            difference: AMOUNT_HEX_MOCK,
+            id: undefined,
+            isAll: false,
+            isDecrease: true,
+            isUnlimited: false,
+            nestedTransactionIndex: 0,
+            newBalance: '0x0',
+            previousBalance: '0x0',
+            standard: SimulationTokenStandard.erc20,
+          },
+        ],
+      },
+    });
+
+    expect(getTokenStandardAndDetailsMock).toHaveBeenCalledWith(
+      TOKEN_ADDRESS_MOCK,
+    );
   });
 
   it('generates unlimited ERC-20 token balance changes', async () => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useBatchApproveBalanceChanges.ts
@@ -93,7 +93,20 @@ async function buildSimulationTokenBalanceChanges({
       continue;
     }
 
-    const tokenData = await getTokenStandardAndDetails(to);
+    const parseResult = parseApprovalTransactionData(data);
+
+    if (!parseResult) {
+      continue;
+    }
+
+    const {
+      amountOrTokenId,
+      isApproveAll: isAll,
+      tokenAddress: token,
+    } = parseResult;
+
+    const tokenAddress = token ?? to;
+    const tokenData = await getTokenStandardAndDetails(tokenAddress);
 
     if (!tokenData?.standard) {
       continue;
@@ -103,14 +116,6 @@ async function buildSimulationTokenBalanceChanges({
       tokenData?.standard?.toLowerCase() as SimulationTokenStandard;
 
     const isNFT = standard !== SimulationTokenStandard.erc20;
-
-    const parseResult = parseApprovalTransactionData(data);
-
-    if (!parseResult) {
-      continue;
-    }
-
-    const { amountOrTokenId, isApproveAll: isAll } = parseResult;
     const amountOrTokenIdHex = add0x(amountOrTokenId?.toString(16) ?? '0x0');
 
     const difference =
@@ -119,10 +124,14 @@ async function buildSimulationTokenBalanceChanges({
     const tokenId = isNFT && amountOrTokenId ? amountOrTokenIdHex : undefined;
 
     const isUnlimited =
-      !isNFT && isSpendingCapUnlimited(amountOrTokenId?.toNumber() ?? 0);
+      !isNFT &&
+      isSpendingCapUnlimited(
+        amountOrTokenId?.toNumber() ?? 0,
+        Number(tokenData?.decimals ?? 0),
+      );
 
     const balanceChange: ApprovalSimulationBalanceChange = {
-      address: to,
+      address: tokenAddress,
       difference,
       id: tokenId,
       isAll: isAll ?? false,

--- a/ui/selectors/multichain.test.ts
+++ b/ui/selectors/multichain.test.ts
@@ -316,10 +316,25 @@ describe('Multichain Selectors', () => {
       expect(getMultichainShouldShowFiat(state)).toBe(getShouldShowFiat(state));
     });
 
-    it('returns true if account is non-EVM', () => {
-      const state = getNonEvmState();
-
+    it('returns true if account is non-EVM and setting currencyRateCheck is true', () => {
+      const state = {
+        metamask: {
+          ...getNonEvmState().metamask,
+          useCurrencyRateCheck: true,
+        },
+      };
       expect(getMultichainShouldShowFiat(state)).toBe(true);
+    });
+    it('returns false if account is non-EVM and setting currencyRateCheck is false', () => {
+      const state = {
+        ...getNonEvmState(),
+        metamask: {
+          ...getNonEvmState().metamask,
+          useCurrencyRateCheck: false,
+        },
+      };
+
+      expect(getMultichainShouldShowFiat(state)).toBe(false);
     });
   });
 

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -59,6 +59,7 @@ import {
   getSelectedAccountCachedBalance,
   getShouldShowFiat,
   getShowFiatInTestnets,
+  getUseCurrencyRateCheck,
 } from './selectors';
 import {
   getSelectedMultichainNetworkConfiguration,
@@ -336,10 +337,12 @@ export function getMultichainShouldShowFiat(
   const selectedAccount = account ?? getSelectedInternalAccount(state);
   const isTestnet = getMultichainIsTestnet(state, selectedAccount);
   const isMainnet = !isTestnet;
+  const useCurrencyRateCheck = getUseCurrencyRateCheck(state);
 
   return getMultichainIsEvm(state, selectedAccount)
     ? getShouldShowFiat(state)
-    : isMainnet || (isTestnet && getShowFiatInTestnets(state));
+    : (useCurrencyRateCheck && isMainnet) ||
+        (useCurrencyRateCheck && isTestnet && getShowFiatInTestnets(state));
 }
 
 export function getMultichainDefaultToken(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
add unlock rate limit error and hint

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/PR?quickstart=1)

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
