### PR TITLE
feat: add error tracing for onboarding flows

### DIFF
--- a/app/scripts/controllers/oauth/oauth-controller.ts
+++ b/app/scripts/controllers/oauth/oauth-controller.ts
@@ -82,6 +82,18 @@ export default class OAuthController extends BaseController<
         url: loginHandler.getAuthUrl(),
       });
       providerLoginSuccess = true;
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      bufferedTrace({
+        name: TraceName.OnboardingOAuthProviderLoginError,
+        op: TraceOperation.OnboardingError,
+        tags: { errorMessage },
+      });
+      bufferedEndTrace({ name: TraceName.OnboardingOAuthProviderLoginError });
+
+      throw error;
     } finally {
       bufferedEndTrace({
         name: TraceName.OnboardingOAuthProviderLogin,
@@ -107,6 +119,20 @@ export default class OAuthController extends BaseController<
       );
       getAuthTokensSuccess = true;
       return loginResult;
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      bufferedTrace({
+        name: TraceName.OnboardingOAuthBYOAServerGetAuthTokensError,
+        op: TraceOperation.OnboardingError,
+        tags: { errorMessage },
+      });
+      bufferedEndTrace({
+        name: TraceName.OnboardingOAuthBYOAServerGetAuthTokensError,
+      });
+
+      throw error;
     } finally {
       bufferedEndTrace({
         name: TraceName.OnboardingOAuthBYOAServerGetAuthTokens,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4906,6 +4906,20 @@ export default class MetamaskController extends EventEmitter {
           );
         isNewUser = newUser;
         seedlessAuthSuccess = true;
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+
+        bufferedTrace({
+          name: TraceName.OnboardingOAuthSeedlessAuthenticateError,
+          op: TraceOperation.OnboardingError,
+          tags: { errorMessage },
+        });
+        bufferedEndTrace({
+          name: TraceName.OnboardingOAuthSeedlessAuthenticateError,
+        });
+
+        throw error;
       } finally {
         bufferedEndTrace({
           name: TraceName.OnboardingOAuthSeedlessAuthenticate,

--- a/shared/lib/trace.ts
+++ b/shared/lib/trace.ts
@@ -58,6 +58,11 @@ export enum TraceName {
   OnboardingOAuthProviderLogin = 'Onboarding - OAuth Provider Login',
   OnboardingOAuthBYOAServerGetAuthTokens = 'Onboarding - OAuth BYOA Server Get Auth Tokens',
   OnboardingOAuthSeedlessAuthenticate = 'Onboarding - OAuth Seedless Authenticate',
+  OnboardingSocialLoginError = 'Onboarding - Social Login Error',
+  OnboardingPasswordLoginError = 'Onboarding - Password Login Error',
+  OnboardingOAuthProviderLoginError = 'Onboarding - OAuth Provider Login Error',
+  OnboardingOAuthBYOAServerGetAuthTokensError = 'Onboarding - OAuth BYOA Server Get Auth Tokens Error',
+  OnboardingOAuthSeedlessAuthenticateError = 'Onboarding - OAuth Seedless Authenticate Error',
 }
 
 /**
@@ -66,6 +71,7 @@ export enum TraceName {
 export enum TraceOperation {
   OnboardingUserJourney = 'onboarding.user_journey',
   OnboardingSecurityOp = 'onboarding.security_operation',
+  OnboardingError = 'onboarding.error',
 }
 
 const log = createModuleLogger(sentryLogger, 'trace');

--- a/ui/pages/onboarding-flow/welcome/welcome.js
+++ b/ui/pages/onboarding-flow/welcome/welcome.js
@@ -172,6 +172,21 @@ export default function OnboardingWelcome({
         ///: BEGIN:ONLY_INCLUDE_IF(build-main,build-beta,build-flask)
         history.push(ONBOARDING_CREATE_PASSWORD_ROUTE);
         ///: END:ONLY_INCLUDE_IF
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+
+        bufferedTrace({
+          name: TraceName.OnboardingSocialLoginError,
+          op: TraceOperation.OnboardingError,
+          tags: { provider: socialConnectionType, errorMessage },
+          parentContext: onboardingParentContext.current,
+        });
+        bufferedEndTrace({ name: TraceName.OnboardingSocialLoginError });
+        bufferedEndTrace({
+          name: TraceName.OnboardingSocialLoginAttempt,
+          data: { success: false },
+        });
       } finally {
         setIsLoggingIn(false);
       }

--- a/ui/pages/unlock-page/unlock-page.component.js
+++ b/ui/pages/unlock-page/unlock-page.component.js
@@ -233,6 +233,17 @@ class UnlockPage extends Component {
     let errorReason;
     let isLocked = false;
 
+    // Check if we are in the onboarding flow
+    if (this.props.onboardingParentContext.current) {
+      bufferedTrace({
+        name: TraceName.OnboardingPasswordLoginError,
+        op: TraceOperation.OnboardingError,
+        tags: { errorMessage: message },
+        parentContext: this.props.onboardingParentContext.current,
+      });
+      bufferedEndTrace({ name: TraceName.OnboardingPasswordLoginError });
+    }
+
     switch (message) {
       case 'Incorrect password':
       case SeedlessOnboardingControllerError.IncorrectPassword:


### PR DESCRIPTION
## **Description**
This PR enhances Sentry tracing for onboarding error states.

The key improvements include:
1.  **Error Traces**: New trace names (`OnboardingSocialLoginError`, `OnboardingPasswordLoginError`, `OnboardingOAuthProviderLoginError`, `OnboardingOAuthBYOAServerGetAuthTokensError`, `OnboardingOAuthSeedlessAuthenticateError`) and a new operation type (`OnboardingError`) have been introduced to specifically capture error details.